### PR TITLE
Remove restriction on IdP Init federation

### DIFF
--- a/draft-ipsie-common-requirements-profile.md
+++ b/draft-ipsie-common-requirements-profile.md
@@ -161,9 +161,8 @@ IPSIE federation protocols are designed to be compliant with many of the technic
 * Subject identifiers may not be globally unique in the absence of additional information. To ensure subject identifier uniqueness RP's MUST use both the subject identifier and a tenant identifier to create globally unique subjects that are bound to the tenant.
 
 * (to be removed later: note the following bullet is related to https://github.com/openid/ipsie/issues/94)
-* All federation transactions MUST originate from the RP.
 * The IdP MAY signal to the RP that the user should be authenticated via federation.
-* Unsolicited federation requests SHALL NOT originate from the IdP (_e.g._ IdP initiated federation).
+
 
 # Security Considerations
 


### PR DESCRIPTION
Removal of language banning IdP init federation. This will be included in the SL2 profiles where appropriate.